### PR TITLE
Fix pbshm-core dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pbshm-framework"
-version = "0.5"
+version = "0.5.1"
 authors = [
     { name = "Dan Brennan", email = "d.s.brennan@sheffield.ac.uk" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 requires-python = ">=3.9.18"
 dependencies = [
-    "pbshm-core == 1.1.2",
+    "pbshm-core >= 1.1.2",
     "pbshm-channel-toolbox >= 0.1.2",
     "pbshm-ie-toolbox >= 0.1.2",
     "pbshm-network-mcs >= 0.1",


### PR DESCRIPTION
Previous version was using an exact version of pbshm-core. Changed to be a minimum required version.