### PR TITLE
Sideload modules

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include rosehips *.html
 recursive-include rosehips *.css
+recursive-include rosehips *.json
 include rosehips/layout/static/*.png

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pbshm-framework"
-version = "0.5"
+version = "0.6"
 authors = [
     { name = "Dan Brennan", email = "d.s.brennan@sheffield.ac.uk" }
 ]

--- a/rosehips/__init__.py
+++ b/rosehips/__init__.py
@@ -5,7 +5,7 @@ from flask import Flask
 
 from pbshm import authentication, initialisation, mechanic, timekeeper, autostat, cleanse, ietools, graphcomparison, ievisualiser
 from pbshm.cleanse import commands as cleanse_commands
-from rosehips import layout
+from rosehips import layout, sideloader
 
 def create_app(test_config=None):
     #Create Flask App
@@ -30,6 +30,9 @@ def create_app(test_config=None):
                 "Channel Statistics": "autostat.population_list",
                 "Cleanse Data": "cleanse.route_list",
                 "IE Debug": "ie-tools.list_models"
+            },
+            "system":{
+                "Sideload Module": "sideloader.list_modules"
             }
         }
     )
@@ -59,6 +62,11 @@ def create_app(test_config=None):
 
     #Add Included Command Blueprints
     app.register_blueprint(cleanse_commands.bp)
+
+    #Add Sideloader Blueprints
+    with app.app_context():
+        sideloader.register_sideloaded_modules()
+    app.register_blueprint(sideloader.bp, url_prefix="/sideloader") ## Sideloader
     
     #Set Root Page
     app.add_url_rule("/", endpoint="layout.home")

--- a/rosehips/sideloader/__init__.py
+++ b/rosehips/sideloader/__init__.py
@@ -1,0 +1,1 @@
+from rosehips.sideloader.sideloader import *

--- a/rosehips/sideloader/sideloader.py
+++ b/rosehips/sideloader/sideloader.py
@@ -1,0 +1,122 @@
+import glob
+import os
+import json
+import sys
+import subprocess
+
+from flask import Blueprint, request, current_app, render_template, jsonify
+from werkzeug.utils import secure_filename
+
+from pbshm.authentication import authenticate_request
+
+#Create sideloader blueprint
+bp = Blueprint(
+    "sideloader",
+    __name__,
+    static_folder = "static",
+    template_folder = "templates"
+)
+
+@bp.route("/", methods=("GET", "POST"))
+@authenticate_request("sideloader-list")
+def list_modules():
+    # Upload
+    error = ""
+    if request.method == "POST":
+        if "configuration" not in request.files:
+            error = "No file found"
+        else:
+            # Ensure JSON file type
+            file = request.files["configuration"]
+            if file.filename.strip() == "":
+                error = "No file selected"
+            elif file.filename.rsplit('.', 1)[1].lower() != "json":
+                error = "The file must be a JSON file"
+            else:
+                # Ensure valid JSON
+                config_str = file.read()
+                config = {}
+                try:
+                    config = json.loads(config_str)
+                except ValueError as err:
+                    error = "Invalid JSON file"
+                if config:
+                    # Ensure required keys
+                    keys = ["package", "namespace", "path", "url_prefix", "blueprint"]
+                    for key in keys:
+                        if key not in config:
+                            error = f"{key} key is missing in JSON"
+                            break
+                        elif not isinstance(config[key], bool) and len(config[key]) == 0:
+                            error = f"{key} key must have a value"
+                            break
+                    if len(error) == 0:
+                        # Ensure package values
+                        package = None
+                        if "name" not in config["package"]:
+                            package = config["package"]
+                        else:
+                            if "source" not in config["package"]:
+                                error = "source key in package is missing in JSON"
+                            elif len(config["package"]["source"]) == 0:
+                                error = "source key in package must have a value"
+                            else:
+                                package = config["package"]["name"]
+                        if package is not None:
+                            # Ensure package configuration
+                            if len(package) == 0:
+                                error = "the name of the package cannot be empty"
+                            elif package.find("git+") == 0:
+                                error = "when using a git+ package url, the name must be declared in the JSON file which matches the name given within the project build file" 
+                            elif os.path.isfile(os.path.join(current_app.instance_path, f"{secure_filename(package)}-disabled.module")):
+                                error = f"there is already a pending module file for {package}"
+                            elif os.path.isfile(os.path.join(current_app.instance_path, f"{secure_filename(package)}.module")):
+                                error = f"there is already an installed module file for {package}"
+                            else:
+                                # Save module config
+                                with open(os.path.join(current_app.instance_path, f"{secure_filename(package)}-disabled.module"), "w", encoding="utf-8") as write_file:
+                                    json.dump(config, write_file, indent=4)
+    # Existing Modules
+    modules = []
+    for config_file in glob.glob(os.path.join(current_app.instance_path, "*.module")):
+        with open(os.path.join(current_app.instance_path, config_file), "r") as module:
+            module_config = json.load(module)
+            module_config["enabled"] = False if config_file.rfind("-disabled.module") == len(config_file) - len("-disabled.module") else True
+            modules.append(module_config)
+    return render_template("sideload-modules.html", modules=modules, error=error)
+
+@bp.route("/install-module/<module_name>", methods=["POST"])
+@authenticate_request("sideloader-install")
+def install_module(module_name: str):
+    if os.path.isfile(os.path.join(current_app.instance_path, f"{module_name}.module")):
+        raise Exception(f"The module {module_name} is already installed on this instance of the framework")
+    if not os.path.isfile(os.path.join(current_app.instance_path, f"{module_name}-disabled.module")):
+        raise Exception(f"The module {module_name} does not exist in this instance of the framework")
+    with open(os.path.join(current_app.instance_path, f"{module_name}-disabled.module"), "r") as module_file:
+        module_config = json.load(module_file)
+        if "source" in module_config["package"]:
+            print(f"Installing module {module_name} via pip package {module_config['package']['name']}({module_config['package']['source']}@{module_config['package']['version'] if 'version' in module_config['package'] else 'latest'})")
+            subprocess.check_call([sys.executable, "-m", "pip", "install", f"{module_config['package']['source']}=={module_config['package']['version']}" if 'version' in module_config['package'] else module_config['package']['source']])
+        else:
+            print(f"Installing module {module_name} via pip package {module_config['package']}")
+            subprocess.check_call([sys.executable, "-m", "pip", "install", module_config["package"]])
+        print(f"Marking module {module_name} as enabled")
+        os.rename(os.path.join(current_app.instance_path, f"{module_name}-disabled.module"), os.path.join(current_app.instance_path, f"{module_name}.module"))
+    return jsonify({"status":"installed"})
+
+@bp.route("/uninstall-module/<module_name>", methods=["POST"])
+@authenticate_request("sideloader-uninstall")
+def uninstall_module(module_name: str):
+    if os.path.isfile(os.path.join(current_app.instance_path, f"{module_name}-disabled.module")):
+        raise Exception(f"The module {module_name} is already uninstalled on this instance of the framework")
+    if not os.path.isfile(os.path.join(current_app.instance_path, f"{module_name}.module")):
+        raise Exception(f"The module {module_name} is not installed on this instance of the framework")
+    with open(os.path.join(current_app.instance_path, f"{module_name}.module"), "r") as module_file:
+        module_config = json.load(module_file)
+        package = module_config["package"]["name"] if "name" in module_config["package"] else module_config["package"]
+        print(f"Uninstalling module {module_name} via pip package {package}")
+        subprocess.check_call([sys.executable, "-m", "pip", "uninstall", "-y", package])
+        print(f"Marking module {module_name} as disabled")
+        os.rename(os.path.join(current_app.instance_path, f"{module_name}.module"), os.path.join(current_app.instance_path, f"{module_name}-disabled.module"))
+    return jsonify({"status":"uninstalled"})
+    

--- a/rosehips/sideloader/sideloader.py
+++ b/rosehips/sideloader/sideloader.py
@@ -1,6 +1,9 @@
 import glob
+import importlib
+import importlib.util
 import os
 import json
+import site
 import sys
 import subprocess
 
@@ -16,6 +19,50 @@ bp = Blueprint(
     static_folder = "static",
     template_folder = "templates"
 )
+
+def register_sideloaded_modules() -> None:
+    #Calculate site packages
+    site_package_paths = site.getsitepackages()
+    default_package_path = os.path.join(site_package_paths[1 if len(site_package_paths) > 1 and sys.platform == "win32" else 0])
+    #Load modules
+    for search_file in glob.glob(os.path.join(current_app.instance_path, "*[!-disabled].module")):
+        with open(os.path.join(current_app.instance_path, search_file), "r") as module_file:
+            #Ensure path
+            module_config = json.load(module_file)
+            module_path = module_config["path"]
+            if len(module_path) < 2:
+                continue
+            #Determine path location
+            selected_module_path, default_search_path = None, os.path.join(default_package_path, *module_path[:-1])
+            if os.path.isdir(default_search_path): selected_module_path = default_search_path
+            else:
+                for potential_path in site_package_paths:
+                    current_search_path = os.path.join(potential_path, *module_path[:-1])
+                    if current_search_path == default_search_path:
+                        continue
+                    elif os.path.isdir(current_search_path):
+                        selected_module_path = current_search_path
+                        break
+            if selected_module_path is None:
+                print(f"Unable to locate path for namespace {module_config['namespace']}")
+                continue
+            #Load module
+            print(f"Registering {module_config['namespace']} from {os.path.join(selected_module_path, module_config['path'][-1])}")
+            module_spec = importlib.util.spec_from_file_location(module_config["namespace"], os.path.join(selected_module_path, module_config["path"][-1]))
+            module = importlib.util.module_from_spec(module_spec)
+            sys.modules[module_config["namespace"]] = module
+            module_spec.loader.exec_module(module)
+            #Register blueprint
+            if module_config["blueprint"]:
+                bp.register_blueprint(module.bp, url_prefix=module_config["url_prefix"])
+            #Navigation
+            for navigation_section in module_config["navigation"]:
+                if navigation_section not in current_app.config["NAVIGATION"]:
+                    current_app.config["NAVIGATION"][navigation_section] = {display_value:f"sideloader.{endpoint_value}" for (display_value, endpoint_value) in module_config["navigation"][navigation_section].items()}
+                else:
+                    for display_value in module_config["navigation"][navigation_section]:
+                        if display_value not in current_app.config["NAVIGATION"][navigation_section]:
+                            current_app.config["NAVIGATION"][navigation_section][display_value] = f"sideloader.{module_config['navigation'][navigation_section][display_value]}"
 
 @bp.route("/", methods=("GET", "POST"))
 @authenticate_request("sideloader-list")
@@ -67,7 +114,7 @@ def list_modules():
                             if len(package) == 0:
                                 error = "the name of the package cannot be empty"
                             elif package.find("git+") == 0:
-                                error = "when using a git+ package url, the name must be declared in the JSON file which matches the name given within the project build file" 
+                                error = "when using a git+ package url, the name must be declared in the JSON file which matches the name given within the project build file"
                             elif os.path.isfile(os.path.join(current_app.instance_path, f"{secure_filename(package)}-disabled.module")):
                                 error = f"there is already a pending module file for {package}"
                             elif os.path.isfile(os.path.join(current_app.instance_path, f"{secure_filename(package)}.module")):
@@ -119,4 +166,3 @@ def uninstall_module(module_name: str):
         print(f"Marking module {module_name} as disabled")
         os.rename(os.path.join(current_app.instance_path, f"{module_name}.module"), os.path.join(current_app.instance_path, f"{module_name}-disabled.module"))
     return jsonify({"status":"uninstalled"})
-    

--- a/rosehips/sideloader/static/sideload.json
+++ b/rosehips/sideloader/static/sideload.json
@@ -1,0 +1,20 @@
+{
+    "package": {
+        "name": "packagename",
+        "source": "git+https://github.com/dsbrennan/package-name",
+        "version": "0.1"
+    },
+    "namespace": "module.namespace",
+    "path": [
+        "module",
+        "namespace",
+        "__init__.py"
+    ],
+    "url_prefix": "/module",
+    "blueprint": true,
+    "navigation": {
+        "system": {
+            "Display name": "endpoint"
+        }
+    }
+}

--- a/rosehips/sideloader/templates/sideload-modules.html
+++ b/rosehips/sideloader/templates/sideload-modules.html
@@ -42,6 +42,11 @@
     <div class="card-header">Error processing upload</div>
     <div class="card-body">{{ error }}</div>
 </div>
+{% else %}
+<div class="card bg-warning text-dark">
+    <div class="card-header font-weight-bold">Warning!</div>
+    <div class="card-body">Sideloading modules enables third party software to be installed into your system and gives them full access to data stored within your database. Installing a third party module may irrevocably damage your system and require a full reinstallation of the framework or system. Only upload a module, if you trust the author of the module and the python running the framework is inside a virtual environment.</div>
+</div>
 {% endif %}
 <div class="card bg-light my-2">
     <div class="card-header">PBSHM Module Configuration (JSON file)</div>

--- a/rosehips/sideloader/templates/sideload-modules.html
+++ b/rosehips/sideloader/templates/sideload-modules.html
@@ -1,0 +1,97 @@
+{% extends 'portal.html' %}
+{% block title %}Sideload PBSHM Modules{% endblock %}
+{% block javascript %}
+<script type="text/javascript">
+    $(document).ready(function(){
+        $("a[data-command='button']").click(function(e){
+            e.preventDefault();
+            var button = $(this);
+            var httpRequest = new XMLHttpRequest();
+            httpRequest.onreadystatechange = function(){
+                if (this.readyState == 4 && this.status == 200) {
+                    response = JSON.parse(this.responseText);
+                    if (response["status"] == "installed") {
+                        button.text("Installed").removeClass("btn-outline-info").addClass("btn-outline-warning");
+                    }
+                    else if (response["status"] == "uninstalled") {
+                        button.text("Uninstalled").removeClass("btn-outline-warning").addClass("btn-outline-info");
+                    }
+                    else {
+                        button.text("Unknown status").removeClass("btn-outline-info").removeClass("btn-outline-warning").addClass("btn-outline-danger");
+                    }
+                }else if (this.readyState == 1){
+                    button.text("Changes pending ...").addClass("disabled");
+                }else if (this.readyState == 4){
+                    button.text("Error").removeClass("btn-outline-info").removeClass("btn-outline-warning").addClass("btn-outline-danger");
+                }
+            };
+            httpRequest.open("POST", button.attr("href"), true);
+            httpRequest.send();
+        })
+    });
+</script>
+{% endblock %}
+{% block content %}
+{% if error|length > 0 %}
+<div class="card bg-danger text-white">
+    <div class="card-header">Error processing upload</div>
+    <div class="card-body">{{ error }}</div>
+</div>
+{% endif %}
+<div class="card bg-light my-2">
+    <div class="card-header">PBSHM Module Configuration (JSON file)</div>
+    <div class="card-body">
+        <form method="POST" enctype="multipart/form-data">
+            <div class="input-group d-flex">
+                <div class="custom-file flex-grow-1">
+                    <input type="file" name="configuration" accept="application/json" class="custom-file-input">
+                    <label for="configuration" class="custom-file-label">Select File</label>
+                </div>
+                <div class="input-group-append">
+                    <input type="submit" name="upload" value="Upload Configuration" class="btn btn-secondary">
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+<table class="table table-borderless table-hover mt-2">
+    <thead class="bg-info text-white">
+        <tr>
+            <th scope="col">Package</th>
+            <th scope="col">Namespace</th>
+            <th scope="col">Path</th>
+            <th scope="col">URL Prefix</th>
+            <th scope="col">Status</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for module in modules %}
+            <tr>
+                <td class="font-weight-bold py-3">{{ module["package"]["name"] if "name" in module["package"] else module["package"] }}</td>
+                <td class="py-3">{{ module["namespace"] }}</td>
+                <td class="py-3">
+                    {% for item in module["path"] %}
+                        {{ ' -> ' + item if loop.index > 1 else item}}
+                    {% endfor %}
+                </td>
+                <td class="py-3">{{ module["url_prefix"] }}</td>
+                <td class="align-middle text-center">
+                    {% if module['enabled'] %}
+                        <a href='{{ url_for("sideloader.uninstall_module", module_name=module["package"]["name"] if "name" in module["package"] else module["package"]) }}'
+                            data-command="button" 
+                            class="btn btn-outline-warning">
+                            Uninstall
+                        </a>
+                    {% else %}
+                        <a href='{{ url_for("sideloader.install_module", module_name=module["package"]["name"] if "name" in module["package"] else module["package"]) }}' 
+                            data-command="button"
+                            class="btn btn-outline-info">
+                            Install
+                        </a>
+                    {% endif %}
+                </td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% endblock %}

--- a/rosehips/sideloader/templates/sideload-modules.html
+++ b/rosehips/sideloader/templates/sideload-modules.html
@@ -31,6 +31,11 @@
     });
 </script>
 {% endblock %}
+{% block title_call_to_action %}
+<a href="{{ url_for('sideloader.static', filename='sideload.json') }}" target="_blank" class="btn btn-secondary">
+    Sideload template
+</a>
+{% endblock %}
 {% block content %}
 {% if error|length > 0 %}
 <div class="card bg-danger text-white">


### PR DESCRIPTION
Framework comes packaged with a list of default pbshm modules which have been tested and linked into the framework; however, for testing and debugging purposes, module authors need the ability to load their pbshm modules into the framework to ensure they comply before being included in the framework.

The sideloader enables modules to be uploaded via a JSON config file and then installed into the framework. The module requires no prior knowledge that it is being installed through the sideloader rather than being installed natively. Once a module has been tested and confirmed working, the module can then be put forth to be considered for inclusion as a native module in the framework.

This feature also enables module to be included within a framework instance, which are not designed to be released publicly due to the confidential nature of the module.