### PR TITLE
Remove python 3.9 and 3.10

### DIFF
--- a/.github/workflows/test-dependencies.yml
+++ b/.github/workflows/test-dependencies.yml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+                python-version: ["3.11", "3.12", "3.13"]
         steps:
             - name: Git checkout
               uses: actions/checkout@v4


### PR DESCRIPTION
Remove the requirement to test the dependencies against python 3.9 and 3.10 [skip ci]