### PR TITLE
Fix typo in dependencies path

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -5,7 +5,7 @@ on:
             - main
 jobs:
     test:
-        uses: ./github/workflows/test-dependencies.yml
+        uses: ./.github/workflows/test-dependencies.yml
     build:
         needs:
             - test


### PR DESCRIPTION
The test job referenced ./github/ instead ./.github/